### PR TITLE
Fixed issue not updating linked lower hint

### DIFF
--- a/js/optimizer.js
+++ b/js/optimizer.js
@@ -5318,7 +5318,7 @@
         // Apply lower hint level to linked row (gold skills)
         if (opts.lowerHint > 0) {
           const linked = row.nextElementSibling;
-          if (linked && linked.classList.contains('linked-lower-row')) {
+          if (linked && linked.classList.contains('linked-lower')) {
             const linkedHint = linked.querySelector('.hint-level');
             if (linkedHint) {
               linkedHint.value = String(opts.lowerHint);


### PR DESCRIPTION
When adding gold skill and setting the lower hint level, it doesn't apply correctly because the HTML class targeted is not the correct one